### PR TITLE
fix: Minor fix for build use in workflow file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       - changes
       - semantic-realease
     if: ${{ needs.changes.outputs.frontend == 'true' }}
-    uses: ./.github/actions/build
+    uses: ./.github/actions/build.yml
     with:
       workspace: frontend
       tags: |
@@ -83,7 +83,7 @@ jobs:
       - changes 
       - semantic-realease
     if: ${{ needs.changes.outputs.backend == 'true' }}
-    uses: ./.github/actions/build
+    uses: ./.github/actions/build.yml
     with:
       workspace: backend
       tags: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       - changes
       - semantic-realease
     if: ${{ needs.changes.outputs.frontend == 'true' }}
-    uses: ./.github/actions/build.yml
+    uses: ./.github/workflows/build.yml
     with:
       workspace: frontend
       tags: |
@@ -83,7 +83,7 @@ jobs:
       - changes 
       - semantic-realease
     if: ${{ needs.changes.outputs.backend == 'true' }}
-    uses: ./.github/actions/build.yml
+    uses: ./.github/workflows/build.yml
     with:
       workspace: backend
       tags: |


### PR DESCRIPTION
This fix fixes the build step, the second error, where `actions` was used instead of `workflows`. This caused the use of global reusable, instead of local.