### PR TITLE
fix: Fix docker tags to use type `raw`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,8 @@ on:
         required: false
         type: string  
         default: |
-          type=ray,value=${{inputs.WORKSPACE}}-latest
-          type=ray,value=${{inputs.WORKSPACE}}-${{ github.sha }}
+          type=raw,value=${{inputs.WORKSPACE}}-latest
+          type=raw,value=${{inputs.WORKSPACE}}-${{ github.sha }}
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,8 +75,8 @@ jobs:
     with:
       workspace: frontend
       tags: |
-        type=ray,value=frontend-latest
-        type=ray,value=frontend-${{ github.sha }}
+        type=raw,value=frontend-latest
+        type=raw,value=frontend-${{ github.sha }}
         type=semver,pattern=frontend-{{major}},value=${{ needs.semantic-realease.outputs.version }}
         type=semver,pattern=frontend-{{major}}.{{minor}},value=${{ needs.semantic-realease.outputs.version }}
         type=semver,pattern=frontend-{{version}},value=${{ needs.semantic-realease.outputs.version }}
@@ -95,8 +95,8 @@ jobs:
     with:
       workspace: backend
       tags: |
-        type=ray,value=backend-latest
-        type=ray,value=backend-${{ github.sha }}
+        type=raw,value=backend-latest
+        type=raw,value=backend-${{ github.sha }}
         type=semver,pattern=backend-{{major}},value=${{ needs.semantic-realease.outputs.version }}
         type=semver,pattern=backend-{{major}}.{{minor}},value=${{ needs.semantic-realease.outputs.version }}
         type=semver,pattern=backend-{{version}},value=${{ needs.semantic-realease.outputs.version }}

--- a/backend/README.md
+++ b/backend/README.md
@@ -16,4 +16,3 @@ This project uses [SemVer](https://semver.org/) for versioning.
 It is done through [semantic-release](https://github.com/semantic-release/semantic-release), and is automated with GitHub actions.
 
 This project will have its Docker image built and pushed to the repository on every push to the `main` branch. This is automated, such that this only happens when changes has been made to the code in this project.
-

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -20,4 +20,3 @@ This project uses [SemVer](https://semver.org/) for versioning.
 It is done through [semantic-release](https://github.com/semantic-release/semantic-release), and is automated with GitHub actions.
 
 This project will have its Docker image built and pushed to the repository on every push to the `main` branch. This is automated, such that this only happens when changes has been made to the code in this project.
-


### PR DESCRIPTION
This fixes a small issue in the type used in the docker tag process, where type `ray` was used instead of `raw`.

Relates to #6