### PR TITLE
fix: Added extra check before building images, to ensure version is available

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
     needs: 
       - changes
       - semantic-realease
-    if: ${{ needs.changes.outputs.frontend == 'true' }}
+    if: ${{ needs.changes.outputs.frontend == 'true' }} && ${{ needs.semantic-realease.outputs.version != '' }}
     uses: ./.github/workflows/build.yml
     with:
       workspace: frontend
@@ -90,7 +90,7 @@ jobs:
     needs:
       - changes 
       - semantic-realease
-    if: ${{ needs.changes.outputs.backend == 'true' }}
+    if: ${{ needs.changes.outputs.backend == 'true' }} && ${{ needs.semantic-realease.outputs.version != '' }}
     uses: ./.github/workflows/build.yml
     with:
       workspace: backend


### PR DESCRIPTION
This update fixes the docker build step, such that the version is needed, before the build step proceeds. This ensures that no image is built without a version.

This relates to #6