### PR TITLE
fix: Updated pipeline to build when there is changes in k8s files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,10 @@ jobs:
         filters: |
           frontend:
             - 'frontend/**'
+            - 'k8s/frontend/**'
           backend:
             - 'backend/**'
+            - 'k8s/backend/**'
 
   semantic-realease:
     name: Semantic release

--- a/backend/README.md
+++ b/backend/README.md
@@ -15,5 +15,5 @@ If redis is not running, you will get a `connection refused` error, don't worry 
 This project uses [SemVer](https://semver.org/) for versioning.    
 It is done through [semantic-release](https://github.com/semantic-release/semantic-release), and is automated with GitHub actions.
 
-This project will have its Docker image built and pushed to the repository on every push to the `main` branch. This is automated, such that this only happens when changes has been made to the code in this project.
+This project will have its Docker image built and pushed to the repository on every push to the `main` branch. This is automated, such that this only happens when changes has been made to the code in this project or to the kubernetes deployment files.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -19,5 +19,5 @@ Go can be in version 1.18 up to at least 1.21.
 This project uses [SemVer](https://semver.org/) for versioning.    
 It is done through [semantic-release](https://github.com/semantic-release/semantic-release), and is automated with GitHub actions.
 
-This project will have its Docker image built and pushed to the repository on every push to the `main` branch. This is automated, such that this only happens when changes has been made to the code in this project.
+This project will have its Docker image built and pushed to the repository on every push to the `main` branch. This is automated, such that this only happens when changes has been made to the code in this project or to the kubernetes deployment files.
 


### PR DESCRIPTION
This update changes the pipeline, such that the build workflow is triggered when the Kubernetes deployment files are updated, as well as when the project files get updated.

This solves #36. 